### PR TITLE
feat: removed `meta` bound info to flat access

### DIFF
--- a/src/core/audio.ts
+++ b/src/core/audio.ts
@@ -21,7 +21,12 @@ interface TranscriptResponse {
  * Use this to initialize an audio stored in VideoDB
  */
 export class Audio implements IAudio {
-  public meta: AudioBase;
+  public readonly id: string;
+  public readonly collectionId: string;
+  public readonly length: string;
+  public readonly name: string;
+  public readonly size: string;
+  public readonly userId: string;
   public transcript?: TranscriptSegment[];
   public transcriptText?: string;
   #vhttp: HttpClient;
@@ -32,7 +37,12 @@ export class Audio implements IAudio {
    * @param data - Data needed to initialize an audio instance
    */
   constructor(http: HttpClient, data: AudioBase) {
-    this.meta = data;
+    this.id = data.id;
+    this.collectionId = data.collectionId;
+    this.length = data.length;
+    this.name = data.name;
+    this.size = data.size;
+    this.userId = data.userId;
     this.#vhttp = http;
   }
 
@@ -44,7 +54,7 @@ export class Audio implements IAudio {
   public delete = async () => {
     return await this.#vhttp.delete<Record<string, never>>([
       audio,
-      this.meta.id,
+      this.id,
     ]);
   };
 
@@ -54,9 +64,9 @@ export class Audio implements IAudio {
    */
   public generateUrl = async (): Promise<string | null> => {
     const res = await this.#vhttp.post<{ signedUrl: string }, object>(
-      [audio, this.meta.id, generate_url],
+      [audio, this.id, generate_url],
       {},
-      { params: { collection_id: this.meta.collectionId } }
+      { params: { collection_id: this.collectionId } }
     );
     return res.data?.signedUrl || null;
   };
@@ -75,7 +85,7 @@ export class Audio implements IAudio {
       return;
     }
     const res = await this.#vhttp.get<TranscriptResponse>(
-      [audio, this.meta.id, transcription],
+      [audio, this.id, transcription],
       {
         params: {
           start,
@@ -135,7 +145,7 @@ export class Audio implements IAudio {
     languageCode?: string
   ): Promise<{ success: boolean; message: string } | TranscriptResponse> => {
     const res = await this.#vhttp.post<TranscriptResponse, object>(
-      [audio, this.meta.id, transcription],
+      [audio, this.id, transcription],
       { force: !!force, languageCode }
     );
     const transcript = res.data?.wordTimestamps;

--- a/src/core/collection.ts
+++ b/src/core/collection.ts
@@ -55,11 +55,15 @@ const {
  * The base class through which all videodb actions are possible
  */
 export class Collection implements ICollection {
-  public meta: CollectionBase;
+  public readonly id: string;
+  public readonly name?: string;
+  public readonly description?: string;
   #vhttp: HttpClient;
 
   constructor(http: HttpClient, data: CollectionBase) {
-    this.meta = data;
+    this.id = data.id;
+    this.name = data.name;
+    this.description = data.description;
     this.#vhttp = http;
   }
 
@@ -69,7 +73,7 @@ export class Collection implements ICollection {
    */
   public getVideos = async () => {
     const res = await this.#vhttp.get<GetVideos>([video], {
-      params: { collection_id: this.meta.id },
+      params: { collection_id: this.id },
     });
     return res.data.videos.map(vid => new Video(this.#vhttp, vid as VideoBase));
   };
@@ -85,7 +89,7 @@ export class Collection implements ICollection {
       throw new VideodbError('Video ID cannot be empty');
     }
     const res = await this.#vhttp.get<VideoResponse>([video, videoId], {
-      params: { collection_id: this.meta.id },
+      params: { collection_id: this.id },
     });
     return new Video(this.#vhttp, res.data as VideoBase);
   };
@@ -101,7 +105,7 @@ export class Collection implements ICollection {
       throw new VideodbError('Video ID cannot be empty');
     }
     return await this.#vhttp.delete<Record<string, never>>([video, videoId], {
-      params: { collection_id: this.meta.id },
+      params: { collection_id: this.id },
     });
   };
 
@@ -111,7 +115,7 @@ export class Collection implements ICollection {
    */
   public getAudios = async () => {
     const res = await this.#vhttp.get<GetAudios>([audio], {
-      params: { collection_id: this.meta.id },
+      params: { collection_id: this.id },
     });
     return res.data.audios.map(aud => new Audio(this.#vhttp, aud as AudioBase));
   };
@@ -127,7 +131,7 @@ export class Collection implements ICollection {
       throw new VideodbError('Audio ID cannot be empty');
     }
     const res = await this.#vhttp.get<AudioResponse>([audio, audioId], {
-      params: { collection_id: this.meta.id },
+      params: { collection_id: this.id },
     });
     return new Audio(this.#vhttp, res.data as AudioBase);
   };
@@ -143,7 +147,7 @@ export class Collection implements ICollection {
       throw new VideodbError('Audio ID cannot be empty');
     }
     return await this.#vhttp.delete<Record<string, never>>([audio, audioId], {
-      params: { collection_id: this.meta.id },
+      params: { collection_id: this.id },
     });
   };
 
@@ -153,7 +157,7 @@ export class Collection implements ICollection {
    */
   public getImages = async () => {
     const res = await this.#vhttp.get<GetImages>([image], {
-      params: { collection_id: this.meta.id },
+      params: { collection_id: this.id },
     });
     return res.data.images.map(img => new Image(this.#vhttp, img as ImageBase));
   };
@@ -169,7 +173,7 @@ export class Collection implements ICollection {
       throw new VideodbError('Image ID cannot be empty');
     }
     const res = await this.#vhttp.get<ImageResponse>([image, imageId], {
-      params: { collection_id: this.meta.id },
+      params: { collection_id: this.id },
     });
     return new Image(this.#vhttp, res.data as ImageBase);
   };
@@ -185,7 +189,7 @@ export class Collection implements ICollection {
       throw new VideodbError('Image ID cannot be empty');
     }
     return await this.#vhttp.delete<Record<string, never>>([image, imageId], {
-      params: { collection_id: this.meta.id },
+      params: { collection_id: this.id },
     });
   };
 
@@ -199,7 +203,7 @@ export class Collection implements ICollection {
    * @returns Video, Audio, or Image object. Returns undefined if callbackUrl is provided.
    */
   public uploadFile = async (data: FileUploadConfig) => {
-    return uploadToServer(this.#vhttp, this.meta.id, data);
+    return uploadToServer(this.#vhttp, this.id, data);
   };
 
   /**
@@ -212,7 +216,7 @@ export class Collection implements ICollection {
    * @returns Video, Audio, or Image object. Returns undefined if callbackUrl is provided.
    */
   public uploadURL = async (data: URLUploadConfig) => {
-    return uploadToServer(this.#vhttp, this.meta.id, data);
+    return uploadToServer(this.#vhttp, this.id, data);
   };
 
   /**
@@ -232,7 +236,7 @@ export class Collection implements ICollection {
     const searchFunc = s.getSearch(searchType ?? DefaultSearchType);
 
     const results = await searchFunc.searchInsideCollection({
-      collectionId: this.meta.id,
+      collectionId: this.id,
       query: query,
       searchType: searchType ?? DefaultSearchType,
       indexType: indexType ?? DefaultIndexType,
@@ -249,7 +253,7 @@ export class Collection implements ICollection {
   public delete = async () => {
     return await this.#vhttp.delete<Record<string, never>>([
       collection,
-      this.meta.id,
+      this.id,
     ]);
   };
 
@@ -266,7 +270,7 @@ export class Collection implements ICollection {
     sampleRate?: number
   ): Promise<RTStream> => {
     const res = await this.#vhttp.post<RTStreamBase, object>([rtstream], {
-      collectionId: this.meta.id,
+      collectionId: this.id,
       url,
       name,
       sampleRate,
@@ -306,7 +310,7 @@ export class Collection implements ICollection {
     callbackUrl?: string
   ): Promise<Image | undefined> => {
     const res = await this.#vhttp.post<ImageBase, object>(
-      [collection, this.meta.id, generate, image],
+      [collection, this.id, generate, image],
       { prompt, aspectRatio, callbackUrl }
     );
     if (res.data) {
@@ -327,7 +331,7 @@ export class Collection implements ICollection {
     callbackUrl?: string
   ): Promise<Audio | undefined> => {
     const res = await this.#vhttp.post<AudioBase, object>(
-      [collection, this.meta.id, generate, audio],
+      [collection, this.id, generate, audio],
       { prompt, duration, audioType: 'music', callbackUrl }
     );
     if (res.data) {
@@ -350,7 +354,7 @@ export class Collection implements ICollection {
     callbackUrl?: string
   ): Promise<Audio | undefined> => {
     const res = await this.#vhttp.post<AudioBase, object>(
-      [collection, this.meta.id, generate, audio],
+      [collection, this.id, generate, audio],
       { prompt, duration, audioType: 'sound_effect', config, callbackUrl }
     );
     if (res.data) {
@@ -373,7 +377,7 @@ export class Collection implements ICollection {
     callbackUrl?: string
   ): Promise<Audio | undefined> => {
     const res = await this.#vhttp.post<AudioBase, object>(
-      [collection, this.meta.id, generate, audio],
+      [collection, this.id, generate, audio],
       { text: textContent, audioType: 'voice', voiceName, config, callbackUrl }
     );
     if (res.data) {
@@ -394,7 +398,7 @@ export class Collection implements ICollection {
     callbackUrl?: string
   ): Promise<Video | undefined> => {
     const res = await this.#vhttp.post<VideoBase, object>(
-      [collection, this.meta.id, generate, video],
+      [collection, this.id, generate, video],
       { prompt, duration, callbackUrl }
     );
     if (res.data) {
@@ -417,7 +421,7 @@ export class Collection implements ICollection {
     const res = await this.#vhttp.post<
       string | Record<string, unknown>,
       object
-    >([collection, this.meta.id, generate, text], {
+    >([collection, this.id, generate, text], {
       prompt,
       modelName,
       responseType,
@@ -438,7 +442,7 @@ export class Collection implements ICollection {
     callbackUrl?: string
   ): Promise<Video | undefined> => {
     const res = await this.#vhttp.post<VideoBase, object>(
-      [collection, this.meta.id, generate, video, dub],
+      [collection, this.id, generate, video, dub],
       { videoId, languageCode, callbackUrl }
     );
     if (res.data) {
@@ -455,7 +459,7 @@ export class Collection implements ICollection {
     query: string
   ): Promise<Array<{ video: Video }>> => {
     const res = await this.#vhttp.post<Array<{ video: VideoBase }>, object>(
-      [collection, this.meta.id, search, title],
+      [collection, this.id, search, title],
       { query, searchType: SearchTypeValues.scene }
     );
     return (res.data || []).map(result => ({
@@ -467,14 +471,14 @@ export class Collection implements ICollection {
    * Make the collection public
    */
   public makePublic = async (): Promise<void> => {
-    await this.#vhttp.patch([collection, this.meta.id], { isPublic: true });
+    await this.#vhttp.patch([collection, this.id], { isPublic: true });
   };
 
   /**
    * Make the collection private
    */
   public makePrivate = async (): Promise<void> => {
-    await this.#vhttp.patch([collection, this.meta.id], { isPublic: false });
+    await this.#vhttp.patch([collection, this.id], { isPublic: false });
   };
 
   /**
@@ -488,7 +492,7 @@ export class Collection implements ICollection {
     const res = await this.#vhttp.post<
       MeetingBase & { meetingId: string },
       object
-    >([collection, this.meta.id, meeting, record], {
+    >([collection, this.id, meeting, record], {
       meetingUrl: config.meetingUrl,
       botName: config.botName,
       botImageUrl: config.botImageUrl,
@@ -500,7 +504,7 @@ export class Collection implements ICollection {
     return new Meeting(this.#vhttp, {
       ...res.data,
       id: res.data.meetingId,
-      collectionId: this.meta.id,
+      collectionId: this.id,
     });
   };
 
@@ -512,7 +516,7 @@ export class Collection implements ICollection {
   public getMeeting = async (meetingId: string): Promise<Meeting> => {
     const meetingObj = new Meeting(this.#vhttp, {
       id: meetingId,
-      collectionId: this.meta.id,
+      collectionId: this.id,
     });
     await meetingObj.refresh();
     return meetingObj;

--- a/src/core/image.ts
+++ b/src/core/image.ts
@@ -10,7 +10,10 @@ const { image, generate_url } = ApiPath;
  * Use this to initialize an Image stored in VideoDB
  */
 export class Image implements IImage {
-  public meta: ImageBase;
+  public readonly id: string;
+  public readonly collectionId?: string;
+  public readonly name?: string;
+  public readonly url?: string;
   #vhttp: HttpClient;
 
   /**
@@ -19,7 +22,10 @@ export class Image implements IImage {
    * @param data - Data needed to initialize an Image instance
    */
   constructor(http: HttpClient, data: ImageBase) {
-    this.meta = data;
+    this.id = data.id;
+    this.collectionId = data.collectionId;
+    this.name = data.name;
+    this.url = data.url;
     this.#vhttp = http;
   }
 
@@ -31,7 +37,7 @@ export class Image implements IImage {
   public delete = async () => {
     return await this.#vhttp.delete<Record<string, never>>([
       image,
-      this.meta.id,
+      this.id,
     ]);
   };
 
@@ -41,9 +47,9 @@ export class Image implements IImage {
    */
   public generateUrl = async (): Promise<string | null> => {
     const res = await this.#vhttp.post<{ signedUrl: string }, object>(
-      [image, this.meta.id, generate_url],
+      [image, this.id, generate_url],
       {},
-      { params: { collection_id: this.meta.collectionId } }
+      { params: { collection_id: this.collectionId } }
     );
     return res.data?.signedUrl || null;
   };
@@ -72,10 +78,10 @@ export class Frame extends Image {
 
   public getRequestData(): object {
     return {
-      id: this.meta.id,
+      id: this.id,
       videoId: this.videoId,
       sceneId: this.sceneId,
-      url: this.meta.url || '',
+      url: this.url || '',
       frameTime: this.frameTime,
       description: this.description,
     };
@@ -87,7 +93,7 @@ export class Frame extends Image {
         ApiPath.video,
         this.videoId,
         ApiPath.frame,
-        this.meta.id,
+        this.id,
         ApiPath.describe,
       ],
       {

--- a/src/core/search/index.ts
+++ b/src/core/search/index.ts
@@ -46,9 +46,12 @@ class SceneSearch implements Search<SceneVideoSearch, SceneCollectionSearch> {
     return new SearchResult(this.#vhttp, res.data);
   };
 
-  searchInsideCollection = async (_data: SceneCollectionSearch) => {
-    throw new Error(
-      'Method not implemented. Scene search is not supported for Collection'
+  searchInsideCollection = (
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _: SceneCollectionSearch
+  ): Promise<SearchResult> => {
+    return Promise.reject(
+      new Error('Scene search is not supported for Collection')
     );
   };
 }
@@ -123,9 +126,12 @@ class KeywordSearch
     return new SearchResult(this.#vhttp, res.data);
   };
 
-  searchInsideCollection = async (data: KeywordCollectionSearch) => {
-    throw new Error(
-      'Method not implemented. Keyword search is not supported for Collection'
+  searchInsideCollection = (
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _: KeywordCollectionSearch
+  ): Promise<SearchResult> => {
+    return Promise.reject(
+      new Error('Keyword search is not supported for Collection')
     );
   };
 }

--- a/src/core/search/searchResult.ts
+++ b/src/core/search/searchResult.ts
@@ -47,9 +47,9 @@ export class SearchResult {
     else if (this.shots.length) {
       const reqData = this.shots.map(shot => {
         return {
-          videoId: shot.meta.videoId,
+          videoId: shot.videoId,
           collectionId: this.collectionId,
-          shots: [[shot.meta.start, shot.meta.end]],
+          shots: [[shot.start, shot.end]],
         };
       });
       const res = await this.#vhttp.post<

--- a/src/core/shot.ts
+++ b/src/core/shot.ts
@@ -11,10 +11,25 @@ const { video, stream } = ApiPath;
  * A shot is a clip of a specific video
  */
 export class Shot implements IShot {
-  meta: ShotBase;
+  public readonly videoId: string;
+  public readonly videoLength: number;
+  public readonly videoTitle: string;
+  public readonly start: number;
+  public readonly end: number;
+  public readonly text?: string;
+  public readonly searchScore?: number;
+  public readonly streamUrl?: string;
   #vhttp: HttpClient;
-  constructor(http: HttpClient, meta: ShotBase) {
-    this.meta = meta;
+
+  constructor(http: HttpClient, data: ShotBase) {
+    this.videoId = data.videoId;
+    this.videoLength = data.videoLength;
+    this.videoTitle = data.videoTitle;
+    this.start = data.start;
+    this.end = data.end;
+    this.text = data.text;
+    this.searchScore = data.searchScore;
+    this.streamUrl = data.streamUrl;
     this.#vhttp = http;
   }
 
@@ -24,12 +39,12 @@ export class Shot implements IShot {
    */
   generateStream = async () => {
     const body = {
-      length: this.meta.videoLength,
-      timeline: [[this.meta.start, this.meta.end]] as Timeline,
+      length: this.videoLength,
+      timeline: [[this.start, this.end]] as Timeline,
     };
 
     const res = await this.#vhttp.post<GenerateStreamResponse, typeof body>(
-      [video, this.meta.videoId, stream],
+      [video, this.videoId, stream],
       body
     );
 

--- a/src/interfaces/core.ts
+++ b/src/interfaces/core.ts
@@ -19,8 +19,7 @@ export interface CollectionBase {
 /**
  * Collection class interface for reference
  */
-export interface ICollection {
-  meta: CollectionBase;
+export interface ICollection extends CollectionBase {
   getVideos: () => Promise<Video[]>;
   getVideo: (videoId: string) => Promise<Video>;
   deleteVideo: (videoId: string) => Promise<object>;
@@ -51,8 +50,8 @@ export interface VideoBase {
 /**
  * Video class interface for reference
  */
-export interface IVideo {
-  meta: VideoBase;
+export interface IVideo extends Omit<VideoBase, 'thumbnail'> {
+  thumbnail?: string;
   transcript?: Transcript;
   generateStream: (timeline: Timeline) => Promise<string>;
   play: () => string;
@@ -79,9 +78,7 @@ export interface AudioBase {
 /**
  * Audio class interface for reference
  */
-export interface IAudio {
-  meta: AudioBase;
-}
+export interface IAudio extends AudioBase {}
 
 /**
  * Base type for all Image objects
@@ -105,7 +102,7 @@ export interface FrameBase {
 /**
  * Image class interface for reference
  */
-export interface IImage {}
+export interface IImage extends ImageBase {}
 
 /**
  * Base type for all Shot objects
@@ -124,8 +121,7 @@ export interface ShotBase {
 /**
  * Shot class interface for reference
  */
-export interface IShot {
-  meta: ShotBase;
+export interface IShot extends ShotBase {
   /**
    * Fetches the streaming Url of the shot
    * @returns An awaited streaming URL


### PR DESCRIPTION
## Pull Request

**Description:**
This PR removes the binding of asset's meta information from a `obj.meta.key` to direct `obj.key`, synonymous to the Python SDK.

Example: 
To access the video id,
Previously: `video.meta.id`
Now: `video.id`

**Changes:**
- [x] removes `this.meta` pattern, expose properties at root level 

**Checklist:**
- [x] Code follows project coding standards
- [ ] Tests have been added or updated
- [ ] Code Review
- [ ] Manual test after merge
- [ ] All checks passed