### PR TITLE
Release 0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.2.4] (2026-03-26)
+
+### Added
+
+- `sortDocsOn` parameter in `Collection.search()` and `Video.search()` to sort docs by "score" or "start"
+- `modelConfig` parameter in `Scene.describe()` for custom model configuration
+- `Video.update()` method to update video metadata (currently supports `name`)
+
+### Changed
+
+- `Video.name` is no longer readonly (required for `update()`)
+- Updated capture binary to v0.3.0
+- Bumped version to 0.2.4
+
+---
+
 ## [0.2.3] (2026-03-18)
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videodb",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "A NodeJS wrapper for VideoDB's API written in TypeScript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -40,11 +40,11 @@
   },
   "binaryConfig": {
     "baseUrl": "https://artifacts.videodb.io/capture",
-    "version": "0.2.10",
+    "version": "0.3.0",
     "checksums": {
-      "darwin-arm64": "fc4be7de94153aa9f492b014db7b4f7378e45c3c6f1b5f3f838c2c007bde832f",
-      "darwin-x64": "bdfc3aa33a961ff532a99639ea95c181d51baee74a1eda555598ce45c30908ac",
-      "win32-x64": "3f9b9a355edc54dd06cef051b0ec7ed55df6beef6eb9e299fa6ba5f02ba3a50a"
+      "darwin-arm64": "4cf3ffadab2e3951819547086ddbad6f6fe2976a35590882a5967fa4ee30a4b7",
+      "darwin-x64": "8e9d2b44bb70bea48f172ca0edb34a5f699b226ff7a795aaf8e5011499596150",
+      "win32-x64": "2f47eac709c5852661ec6d073fb3691800e208a348c9d6cad61841d26eea89f4"
     }
   },
   "repository": {

--- a/src/capture/installer.ts
+++ b/src/capture/installer.ts
@@ -37,11 +37,11 @@ export class RecorderInstaller {
     // Default binary config - can be overridden or loaded from package.json
     this.binaryConfig = binaryConfig || {
       baseUrl: 'https://artifacts.videodb.io/capture',
-      version: '0.2.10',
+      version: '0.3.0',
       checksums: {
-        'darwin-x64': 'bdfc3aa33a961ff532a99639ea95c181d51baee74a1eda555598ce45c30908ac',
-        'darwin-arm64': 'fc4be7de94153aa9f492b014db7b4f7378e45c3c6f1b5f3f838c2c007bde832f',
-        'win32-x64': '3f9b9a355edc54dd06cef051b0ec7ed55df6beef6eb9e299fa6ba5f02ba3a50a',
+        'darwin-x64': '8e9d2b44bb70bea48f172ca0edb34a5f699b226ff7a795aaf8e5011499596150',
+        'darwin-arm64': '4cf3ffadab2e3951819547086ddbad6f6fe2976a35590882a5967fa4ee30a4b7',
+        'win32-x64': '2f47eac709c5852661ec6d073fb3691800e208a348c9d6cad61841d26eea89f4',
       },
     };
 

--- a/src/core/collection.ts
+++ b/src/core/collection.ts
@@ -238,6 +238,7 @@ export class Collection implements ICollection {
    * @param scoreThreshold - [optional] Score Threshold
    * @param dynamicScorePercentage - [optional] Percentage of dynamic score to consider
    * @param filter - [optional] Additional metadata filters
+   * @param sortDocsOn - [optional] Sort docs within each video by "score" or "start"
    * @param namespace - [optional] Search namespace ("rtstream" to search RTStreams)
    * @param sceneIndexId - [optional] Filter by specific scene index
    * @returns SearchResult or RTStreamSearchResult object
@@ -250,6 +251,7 @@ export class Collection implements ICollection {
     scoreThreshold?: number,
     dynamicScorePercentage?: number,
     filter?: Array<Record<string, unknown>>,
+    sortDocsOn?: string,
     namespace?: string,
     sceneIndexId?: string
   ): Promise<SearchResult | RTStreamSearchResult> => {
@@ -302,6 +304,7 @@ export class Collection implements ICollection {
       scoreThreshold: scoreThreshold,
       dynamicScorePercentage: dynamicScorePercentage,
       filter: filter,
+      sortDocsOn: sortDocsOn,
     });
     return results;
   };

--- a/src/core/scene.ts
+++ b/src/core/scene.ts
@@ -40,12 +40,13 @@ export class Scene {
     this.#vhttp = http;
   }
 
-  public async describe(prompt?: string, modelName?: string): Promise<string> {
+  public async describe(prompt?: string, modelName?: string, modelConfig?: Record<string, unknown>): Promise<string> {
     const response = await this.#vhttp.post<{ description: string }, object>(
       [ApiPath.video, this.videoId, ApiPath.scene, this.id, ApiPath.describe],
       {
         prompt,
         model_name: modelName,
+        model_config: modelConfig,
       }
     );
     this.description = response.data.description;

--- a/src/core/search/index.ts
+++ b/src/core/search/index.ts
@@ -90,6 +90,9 @@ class SemanticSearch
     if (data.filter !== undefined) {
       reqData.filter = data.filter;
     }
+    if (data.sortDocsOn !== undefined) {
+      reqData.sort_docs_on = data.sortDocsOn;
+    }
     return reqData;
   };
 

--- a/src/core/video.ts
+++ b/src/core/video.ts
@@ -74,7 +74,7 @@ export class Video implements IVideo {
   public readonly id: string;
   public readonly collectionId: string;
   public readonly length: string;
-  public readonly name: string;
+  public name: string;
   public readonly description?: string;
   public readonly size: string;
   public readonly streamUrl: string;
@@ -112,6 +112,7 @@ export class Video implements IVideo {
    * @param scoreThreshold - [optional] Score Threshold
    * @param dynamicScorePercentage - [optional] Percentage of dynamic score to consider
    * @param filter - [optional] Additional metadata filters
+   * @param sortDocsOn - [optional] Sort docs within each video by "score" or "start"
    */
   public search = async (
     query: string,
@@ -120,7 +121,8 @@ export class Video implements IVideo {
     resultThreshold?: number,
     scoreThreshold?: number,
     dynamicScorePercentage?: number,
-    filter?: Array<Record<string, unknown>>
+    filter?: Array<Record<string, unknown>>,
+    sortDocsOn?: string
   ) => {
     const s = new SearchFactory(this.#vhttp);
     const searchFunc = s.getSearch(searchType ?? DefaultSearchType);
@@ -133,8 +135,24 @@ export class Video implements IVideo {
       scoreThreshold: scoreThreshold,
       dynamicScorePercentage: dynamicScorePercentage,
       filter: filter,
+      sortDocsOn: sortDocsOn,
     });
     return results;
+  };
+
+  /**
+   * Update the video's metadata
+   * @param options - Fields to update
+   * @param options.name - New name for the video
+   */
+  public update = async (options: { name?: string }) => {
+    const data: Record<string, unknown> = {};
+    if (options.name !== undefined) data.name = options.name;
+    const res = await this.#vhttp.patch<{ id: string; name: string }, typeof data>(
+      [video, this.id],
+      data
+    );
+    if (options.name !== undefined) this.name = res.data.name ?? options.name;
   };
 
   /**

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -11,6 +11,7 @@ export type SearchBase = {
   scoreThreshold?: number;
   dynamicScorePercentage?: number;
   filter?: Array<Record<string, unknown>>;
+  sortDocsOn?: string;
 };
 
 export type SemanticSearchBase = SearchBase;


### PR DESCRIPTION
## Pull Request

**Description:**
Release 0.2.4 — adds search sorting, scene describe model config, video update method, and capture binary bump.

**Changes:**
- [x] Add `sortDocsOn` parameter to `Collection.search()` and `Video.search()` for sorting docs within each video by `"score"` or `"start"`
- [x] Add `modelConfig` parameter to `Scene.describe()` for passing custom model configuration alongside `modelName`
- [x] Add `Video.update({ name })` method to update video metadata via `PATCH /video/{video_id}`
- [x] Change `Video.name` from `readonly` to mutable (required for `update()`)
- [x] Bump version to `0.2.4`
- [x] Update capture binary from `v0.2.10` to `v0.3.0` with new checksums (package.json + installer.ts)

**Related Issues:**
- DeepSearch production launch requires `sortDocsOn` in the main SDK
- `modelConfig` needed for custom LLM config in scene description workflows

**Testing:**
- [ ] `sortDocsOn` — verify search results respect sort order when passing `"score"` or `"start"`
- [ ] `Scene.describe(prompt, modelName, modelConfig)` — verify model config is forwarded to the API and description is returned
- [ ] `Video.update({ name })` — verify name update via PATCH and that `video.name` reflects the change
- [ ] Capture binary `v0.3.0` — verify `npm install videodb` pulls and installs the correct binary version on darwin-arm64, darwin-x64, and win32-x64
- [ ] Regression: ensure existing `Collection.search()`, `Video.search()`, and `Scene.describe()` calls without the new params still work as before
- [ ] TypeScript build passes (`npx tsc --noEmit`)
