### PR TITLE
Release 0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 - Binary updates for better audio input device support
 - Updated capture binary to v0.3.1
+- Split `SearchTypeValues` into public (`semantic`, `keyword`) and internal (`InternalSearchTypeValues`: `scene`, `llm`) to avoid exposing unsupported search types to users
+
+### Fixed
+
+- Added input validation for `segmenter`, `start`, and `end` in `Video.getTranscript()` and `Audio.getTranscript()`
+- Fixed file upload name extraction for paths containing dots
+- Improved `getTranscript` docstrings for both Video and Audio
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.2.5] (2026-04-03)
+
+### Changed
+
+- Binary updates for better audio input device support
+- Updated capture binary to v0.3.1
+
+---
+
 ## [0.2.4] (2026-03-26)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videodb",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "A NodeJS wrapper for VideoDB's API written in TypeScript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -40,11 +40,11 @@
   },
   "binaryConfig": {
     "baseUrl": "https://artifacts.videodb.io/capture",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "checksums": {
-      "darwin-arm64": "4cf3ffadab2e3951819547086ddbad6f6fe2976a35590882a5967fa4ee30a4b7",
-      "darwin-x64": "8e9d2b44bb70bea48f172ca0edb34a5f699b226ff7a795aaf8e5011499596150",
-      "win32-x64": "2f47eac709c5852661ec6d073fb3691800e208a348c9d6cad61841d26eea89f4"
+      "darwin-arm64": "cefc35883acd53f63dc50f8deb186ea0a8e17c65e646af8e81a309251a220b9d",
+      "darwin-x64": "8b456607ba3628092081d92c1a22fcf4e8156f4e83b2d3d119bf0244eaa870b2",
+      "win32-x64": "e388639c15ab35ac32179d3fc05a363f0f71d4d90265c6b48fb1af56ecae7736"
     }
   },
   "repository": {

--- a/src/capture/installer.ts
+++ b/src/capture/installer.ts
@@ -37,11 +37,11 @@ export class RecorderInstaller {
     // Default binary config - can be overridden or loaded from package.json
     this.binaryConfig = binaryConfig || {
       baseUrl: 'https://artifacts.videodb.io/capture',
-      version: '0.3.0',
+      version: '0.3.1',
       checksums: {
-        'darwin-x64': '8e9d2b44bb70bea48f172ca0edb34a5f699b226ff7a795aaf8e5011499596150',
-        'darwin-arm64': '4cf3ffadab2e3951819547086ddbad6f6fe2976a35590882a5967fa4ee30a4b7',
-        'win32-x64': '2f47eac709c5852661ec6d073fb3691800e208a348c9d6cad61841d26eea89f4',
+        'darwin-x64': '8b456607ba3628092081d92c1a22fcf4e8156f4e83b2d3d119bf0244eaa870b2',
+        'darwin-arm64': 'cefc35883acd53f63dc50f8deb186ea0a8e17c65e646af8e81a309251a220b9d',
+        'win32-x64': 'e388639c15ab35ac32179d3fc05a363f0f71d4d90265c6b48fb1af56ecae7736',
       },
     };
 

--- a/src/core/audio.ts
+++ b/src/core/audio.ts
@@ -1,6 +1,9 @@
 import { ApiPath, Segmenter } from '@/constants';
 import type { AudioBase, IAudio } from '@/interfaces/core';
 import { HttpClient } from '@/utils/httpClient';
+import { VideodbError } from '@/utils/error';
+
+const VALID_SEGMENTERS: Set<string> = new Set([Segmenter.word, Segmenter.sentence, Segmenter.time]);
 
 const { audio, generate_url, transcription } = ApiPath;
 
@@ -78,6 +81,22 @@ export class Audio implements IAudio {
     length: number = 1,
     force?: boolean
   ): Promise<void> => {
+    if (!VALID_SEGMENTERS.has(segmenter)) {
+      throw new VideodbError(
+        `Invalid segmenter '${segmenter}'. Must be one of: ${[...VALID_SEGMENTERS].sort().join(', ')}`
+      );
+    }
+    if (start !== undefined && start < 0) {
+      throw new VideodbError(`start must be non-negative, got ${start}`);
+    }
+    if (end !== undefined && end < 0) {
+      throw new VideodbError(`end must be non-negative, got ${end}`);
+    }
+    if (start !== undefined && end !== undefined && start > end) {
+      throw new VideodbError(
+        `start (${start}) must be less than or equal to end (${end})`
+      );
+    }
     if (this.transcript && !force && !start && !end) {
       return;
     }
@@ -99,11 +118,17 @@ export class Audio implements IAudio {
 
   /**
    * Get timestamped transcript segments for the audio
-   * @param start - Start time in seconds
-   * @param end - End time in seconds
-   * @param segmenter - Segmentation type (word, sentence, time)
-   * @param length - Length of segments when using time segmenter
-   * @param force - Force fetch new transcript
+   * @param start - Start time in seconds (must be >= 0 and <= end)
+   * @param end - End time in seconds (must be >= 0 and >= start)
+   * @param segmenter - How to split the transcript into segments.
+   *   Must be one of `Segmenter.word` (default, one segment per word),
+   *   `Segmenter.sentence` (one segment per sentence), or
+   *   `Segmenter.time` (fixed-duration segments controlled by `length`)
+   * @param length - Duration in seconds for each segment when
+   *   segmenter is `Segmenter.time` (default 1)
+   * @param force - Force re-fetch transcript from the server, bypassing the local cache
+   * @throws {VideodbError} If segmenter is not a valid value, or if
+   *   start/end are negative or start > end
    * @returns List of transcript segments
    */
   public getTranscript = async (

--- a/src/core/collection.ts
+++ b/src/core/collection.ts
@@ -30,7 +30,7 @@ import { uploadToServer } from '@/utils/upload';
 import {
   DefaultSearchType,
   DefaultIndexType,
-  SearchTypeValues,
+  InternalSearchTypeValues,
 } from '@/core/config';
 import { SearchFactory } from './search';
 import { SearchResult } from './search/searchResult';
@@ -567,7 +567,7 @@ export class Collection implements ICollection {
   ): Promise<Array<{ video: Video }>> => {
     const res = await this.#vhttp.post<Array<{ video: VideoBase }>, object>(
       [collection, this.id, search, title],
-      { query, search_type: SearchTypeValues.llm }
+      { query, search_type: InternalSearchTypeValues.llm }
     );
     return (res.data || []).map(result => ({
       video: new Video(this.#vhttp, result.video),

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -147,6 +147,10 @@ export const TextStyleDefaultValues: TextStyleProps = {
 export enum SearchTypeValues {
   keyword = 'keyword',
   semantic = 'semantic',
+}
+
+/** Search types used internally by the SDK.  */
+export enum InternalSearchTypeValues {
   scene = 'scene',
   llm = 'llm',
 }

--- a/src/core/search/index.ts
+++ b/src/core/search/index.ts
@@ -4,8 +4,8 @@ import {
   KeywordSearchDefaultValues,
 } from '@/constants';
 import type { Search } from '@/interfaces/core';
-import type { SearchType } from '@/types/search';
-import { IndexTypeValues, SearchTypeValues } from '@/core/config';
+import type { AnySearchType } from '@/types/search';
+import { IndexTypeValues, SearchTypeValues, InternalSearchTypeValues } from '@/core/config';
 import type { SearchResponse } from '@/types/response';
 import type {
   KeywordCollectionSearch,
@@ -28,7 +28,7 @@ class SceneSearch implements Search<SceneVideoSearch, SceneCollectionSearch> {
 
   private getRequestData = (data: SceneVideoSearch | SceneCollectionSearch) => {
     const reqData: Record<string, unknown> = {
-      search_type: data.searchType ?? SearchTypeValues.scene,
+      search_type: data.searchType ?? InternalSearchTypeValues.scene,
       index_type: IndexTypeValues.scene,
       query: data.query,
       score_threshold:
@@ -175,8 +175,8 @@ class LLMSearch
     data: SemanticVideoSearch | SemanticCollectionSearch
   ) => {
     const reqData: Record<string, unknown> = {
-      search_type: data.searchType ?? SearchTypeValues.llm,
-      index_type: data.indexType ?? SearchTypeValues.llm,
+      search_type: data.searchType ?? InternalSearchTypeValues.llm,
+      index_type: data.indexType ?? InternalSearchTypeValues.llm,
       query: data.query,
       score_threshold:
         data.scoreThreshold ?? SemanticSearchDefaultValues.scoreThreshold,
@@ -223,7 +223,7 @@ export class SearchFactory {
   constructor(http: HttpClient) {
     this.vhttp = http;
   }
-  getSearch(type: SearchType) {
+  getSearch(type: AnySearchType) {
     return new searchType[type](this.vhttp);
   }
 }

--- a/src/core/video.ts
+++ b/src/core/video.ts
@@ -65,6 +65,8 @@ const {
   clip,
 } = ApiPath;
 
+const VALID_SEGMENTERS: Set<string> = new Set([Segmenter.word, Segmenter.sentence, Segmenter.time]);
+
 /**
  * The base Video class
  * @remarks
@@ -214,11 +216,17 @@ export class Video implements IVideo {
   /**
    * Fetches the transcript of the video if it exists, generates one
    * if it doesn't.
-   * @param start - Start time in seconds (optional)
-   * @param end - End time in seconds (optional)
-   * @param segmenter - Segmentation type (word, sentence, time) (optional)
-   * @param length - Length of segments when using time segmenter (optional)
-   * @param force - Force fetch new transcript (optional)
+   * @param start - Start time in seconds (must be >= 0 and <= end)
+   * @param end - End time in seconds (must be >= 0 and >= start)
+   * @param segmenter - How to split the transcript into segments.
+   *   Must be one of `Segmenter.word` (default, one segment per word),
+   *   `Segmenter.sentence` (one segment per sentence), or
+   *   `Segmenter.time` (fixed-duration segments controlled by `length`)
+   * @param length - Duration in seconds for each segment when
+   *   segmenter is `Segmenter.time` (default 1)
+   * @param force - Force re-fetch transcript from the server, bypassing the local cache
+   * @throws {VideodbError} If segmenter is not a valid value, or if
+   *   start/end are negative or start > end
    * @returns The transcript data
    */
   public getTranscript = async (
@@ -228,6 +236,22 @@ export class Video implements IVideo {
     length?: number,
     force?: boolean
   ): Promise<Transcript> => {
+    if (segmenter !== undefined && !VALID_SEGMENTERS.has(segmenter)) {
+      throw new VideodbError(
+        `Invalid segmenter '${segmenter}'. Must be one of: ${[...VALID_SEGMENTERS].sort().join(', ')}`
+      );
+    }
+    if (start !== undefined && start < 0) {
+      throw new VideodbError(`start must be non-negative, got ${start}`);
+    }
+    if (end !== undefined && end < 0) {
+      throw new VideodbError(`end must be non-negative, got ${end}`);
+    }
+    if (start !== undefined && end !== undefined && start > end) {
+      throw new VideodbError(
+        `start (${start}) must be less than or equal to end (${end})`
+      );
+    }
     if (this.transcript && !start && !end && !segmenter && !length && !force) {
       return this.transcript;
     }

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -1,6 +1,8 @@
-import { IndexTypeValues, SearchTypeValues } from '@/core/config';
+import { IndexTypeValues, SearchTypeValues, InternalSearchTypeValues } from '@/core/config';
 
 export type SearchType = keyof typeof SearchTypeValues;
+export type InternalSearchType = keyof typeof InternalSearchTypeValues;
+export type AnySearchType = SearchType | InternalSearchType;
 export type IndexType = `${IndexTypeValues}`;
 
 export type SearchBase = {

--- a/src/utils/upload.ts
+++ b/src/utils/upload.ts
@@ -8,6 +8,7 @@ import { Image } from '@/core/image';
 import type { AudioBase, ImageBase, VideoBase } from '@/interfaces/core';
 import FormData from 'form-data';
 import { createReadStream } from 'fs';
+import { parse } from 'path';
 import { HttpClient } from './httpClient';
 
 const { upload_url, collection, upload } = ApiPath;
@@ -61,9 +62,11 @@ export const uploadToServer = async (
     urlToUpload = data.url;
   }
 
+  const name = data.name || ('filePath' in data ? parse(data.filePath).name : undefined);
+
   const finalData = {
     url: urlToUpload,
-    name: data.name,
+    name,
     description: data.description,
     callback_url: data.callbackUrl,
     media_type: data.mediaType,


### PR DESCRIPTION
## Description
Release 0.2.6 — input validation improvements, internal search type cleanup, capture binary update, and dependency pinning.

## Changes

### Bug Fixes
- [x] Segmenter validation in `Video.getTranscript()` and `Audio.getTranscript()` — rejects invalid values with clear error messages
- [x] Internal search types (`scene`, `llm`) moved to `InternalSearchTypeValues` — no longer exposed via public `SearchTypeValues`
- [x] Upload path parsing uses `path.parse()` instead of naive string split — fixes filenames with dots

### Dependencies
- [x] Capture binary updated to v0.3.1 (better audio input device support)


### Documentation
- [x] Updated CHANGELOG for 0.2.6
- [x] Improved `getTranscript` docstrings for both Video and Audio

## Testing
- [x] Verify `getTranscript()` raises error on invalid segmenter, negative start/end, start > end
- [x] Verify `SearchTypeValues` only exposes `semantic` and `keyword`
- [x] Verify upload works with filenames containing multiple dots (e.g., `my.video.file.mp4`)
- [x] Verify capture binary v0.3.1 installs correctly
