### PR TITLE
Fix audio/video length type and deprecate old Timeline

### DIFF
--- a/src/core/audio.ts
+++ b/src/core/audio.ts
@@ -26,7 +26,7 @@ interface TranscriptResponse {
 export class Audio implements IAudio {
   public readonly id: string;
   public readonly collectionId: string;
-  public readonly length: string;
+  public readonly length: number;
   public readonly name: string;
   public readonly size: string;
   public readonly userId: string;
@@ -42,7 +42,7 @@ export class Audio implements IAudio {
   constructor(http: HttpClient, data: AudioBase) {
     this.id = data.id;
     this.collectionId = data.collectionId;
-    this.length = data.length;
+    this.length = Number(data.length) || 0;
     this.name = data.name;
     this.size = data.size;
     this.userId = data.userId;

--- a/src/core/timeline.ts
+++ b/src/core/timeline.ts
@@ -19,6 +19,10 @@ export class Timeline implements ITimeline {
    * @returns Timeline object
    */
   constructor(connection: Connection) {
+    console.warn(
+      'Timeline from videodb/core/timeline is deprecated and will be removed in a future release. ' +
+      'Use EditorTimeline from videodb/core/editor instead.'
+    );
     this.#vhttp = connection.vhttp;
     this.timeline = [];
     this.streamUrl = '';

--- a/src/core/video.ts
+++ b/src/core/video.ts
@@ -75,7 +75,7 @@ const VALID_SEGMENTERS: Set<string> = new Set([Segmenter.word, Segmenter.sentenc
 export class Video implements IVideo {
   public readonly id: string;
   public readonly collectionId: string;
-  public readonly length: string;
+  public readonly length: number;
   public name: string;
   public readonly description?: string;
   public readonly size: string;
@@ -94,7 +94,7 @@ export class Video implements IVideo {
   constructor(http: HttpClient, data: VideoBase) {
     this.id = data.id;
     this.collectionId = data.collectionId;
-    this.length = data.length;
+    this.length = Number(data.length) || 0;
     this.name = data.name;
     this.description = data.description;
     this.size = data.size;
@@ -177,7 +177,7 @@ export class Video implements IVideo {
     }
 
     const body: { length: number; timeline?: Timeline } = {
-      length: Number(this.length),
+      length: this.length,
     };
     if (timeline) body.timeline = timeline;
 
@@ -735,7 +735,7 @@ export class Video implements IVideo {
     insertVideo: Video,
     timestamp: number
   ): Promise<string | null> => {
-    const videoLength = Number(this.length);
+    const videoLength = this.length;
     if (timestamp > videoLength) {
       timestamp = videoLength;
     }

--- a/src/interfaces/core.ts
+++ b/src/interfaces/core.ts
@@ -41,7 +41,7 @@ export interface ICollection extends CollectionBase {
 export interface VideoBase {
   collectionId: string;
   id: string;
-  length: string;
+  length: string | number;
   name: string;
   description?: string;
   size: string;
@@ -84,7 +84,7 @@ export interface IVideo extends Omit<VideoBase, 'thumbnail'> {
 export interface AudioBase {
   collectionId: string;
   id: string;
-  length: string;
+  length: string | number;
   name: string;
   size: string;
   userId: string;


### PR DESCRIPTION
- Cast Audio.length and Video.length to number on init (was stored as raw string from API). Remove redundant Number() casts in video.ts.
- Update AudioBase.length and VideoBase.length interfaces to string | number
- Add console.warn deprecation to Timeline, directing users to EditorTimeline
