### PR TITLE
Release 0.2.6

### DIFF
--- a/src/core/editor.ts
+++ b/src/core/editor.ts
@@ -480,8 +480,6 @@ export class EditorVideoAsset {
     const volume = config.volume ?? 1;
 
     if (start < 0) throw new Error('start must be non-negative');
-    if (volume < 0 || volume > 5)
-      throw new Error('volume must be between 0 and 5');
 
     this.id = config.id;
     this.start = start;
@@ -538,8 +536,6 @@ export class EditorAudioAsset {
 
   constructor(config: EditorAudioAssetConfig) {
     const volume = config.volume ?? 1;
-    if (volume < 0 || volume > 5)
-      throw new Error('volume must be between 0 and 5');
     this.id = config.id;
     this.start = config.start ?? 0;
     this.volume = volume;

--- a/src/core/editor.ts
+++ b/src/core/editor.ts
@@ -537,9 +537,12 @@ export class EditorAudioAsset {
   public volume: number;
 
   constructor(config: EditorAudioAssetConfig) {
+    const volume = config.volume ?? 1;
+    if (volume < 0 || volume > 5)
+      throw new Error('volume must be between 0 and 5');
     this.id = config.id;
     this.start = config.start ?? 0;
-    this.volume = config.volume ?? 1;
+    this.volume = volume;
   }
 
   toJSON(): BaseAssetJSON {

--- a/src/core/image.ts
+++ b/src/core/image.ts
@@ -84,12 +84,13 @@ export class Frame extends Image {
     };
   }
 
-  public async describe(prompt?: string, modelName?: string): Promise<string> {
+  public async describe(prompt?: string, modelName?: string, modelConfig?: Record<string, unknown>): Promise<string> {
     const response = await this.#vhttp.post<{ description: string }, object>(
       [ApiPath.video, this.videoId, ApiPath.frame, this.id, ApiPath.describe],
       {
         prompt,
         model_name: modelName,
+        model_config: modelConfig,
       }
     );
     this.description = response.data.description;


### PR DESCRIPTION
## Pull Request  

**Description:**  
Adds initial volume validation for EditorAudioAsset to align with EditorVideoAsset behavior and introduces modelConfig support in Frame.describe() for consistency with Scene.describe(). Subsequently removes volume validation from editor assets to delegate enforcement to the service layer.  

**Changes:**  
- [x] Add volume validation (0–5) to EditorAudioAsset  
- [x] Add `modelConfig` support to `Frame.describe()`  
- [x] Align API behavior with `Scene.describe()`  
- [x] Remove volume validation from editor assets (moved to service layer)  