### PR TITLE
fix: add node: prefix to all Node.js built-in module imports

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -1,8 +1,8 @@
-const fs = require('fs');
-const path = require('path');
-const https = require('https');
-const crypto = require('crypto');
-const { execFileSync } = require('child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const https = require('node:https');
+const crypto = require('node:crypto');
+const { execFileSync } = require('node:child_process');
 const tar = require('tar');
 
 const MACOS_APP_BUNDLE = 'VideoDBCapture.app';

--- a/src/capture/binaryManager.ts
+++ b/src/capture/binaryManager.ts
@@ -1,6 +1,6 @@
-import { spawn, type ChildProcess } from 'child_process';
-import * as readline from 'readline';
-import { EventEmitter } from 'events';
+import { spawn, type ChildProcess } from 'node:child_process';
+import * as readline from 'node:readline';
+import { EventEmitter } from 'node:events';
 import { v4 as uuidv4 } from 'uuid';
 import {
   PROTOCOL_PREFIX,
@@ -49,7 +49,7 @@ export class BinaryManager extends EventEmitter {
   private getBinaryCommand(): { command: string; args: string[] } {
     if (this.isDev) {
       // In dev mode, use a mock binary (Node.js script)
-      const path = require('path');
+      const path = require('node:path');
       return {
         command: 'node',
         args: [path.join(__dirname, '..', '..', 'mock', 'binary.js')],
@@ -88,7 +88,7 @@ export class BinaryManager extends EventEmitter {
    */
   private handleMessage(msg: BinaryMessage): void {
     if (msg.type === 'response') {
-      const response = msg as BinaryResponse;
+      const response = msg;
       const { commandId, status, result } = response;
       const promise = this.pendingCommands.get(commandId);
       if (promise) {
@@ -100,7 +100,7 @@ export class BinaryManager extends EventEmitter {
         this.pendingCommands.delete(commandId);
       }
     } else if (msg.type === 'event') {
-      const event = msg as BinaryEvent;
+      const event = msg;
       this.emit(event.event, event.payload);
     }
   }
@@ -301,7 +301,7 @@ export class BinaryManager extends EventEmitter {
         resolve: resolve as (value: unknown) => void,
         reject,
       });
-      this.process!.stdin!.write(payload, (err) => {
+      this.process!.stdin!.write(payload, err => {
         if (err) {
           const pending = this.pendingCommands.get(commandId);
           if (pending) {

--- a/src/capture/captureClient.ts
+++ b/src/capture/captureClient.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 import { BinaryManager } from './binaryManager';
 import {
   PermissionType,
@@ -244,8 +244,9 @@ export class CaptureClient extends EventEmitter implements ChannelClient {
       throw new Error('channels must include channelId for each channel');
     }
 
-    const primaryVideo = channels.find(ch => ch.is_primary && ch.type === 'video')
-      || channels.find(ch => ch.type === 'video');
+    const primaryVideo =
+      channels.find(ch => ch.is_primary && ch.type === 'video') ||
+      channels.find(ch => ch.type === 'video');
 
     await this.binaryManager.sendCommand('startRecording', {
       uploadToken: this.sessionToken,

--- a/src/capture/installer.ts
+++ b/src/capture/installer.ts
@@ -1,8 +1,8 @@
-import * as fs from 'fs';
-import * as path from 'path';
-import * as https from 'https';
-import * as crypto from 'crypto';
-import { execFileSync } from 'child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as https from 'node:https';
+import * as crypto from 'node:crypto';
+import { execFileSync } from 'node:child_process';
 import type { BinaryConfig, PlatformInfo } from './types';
 
 /** Name of the macOS .app bundle that wraps the capture binary for TCC compatibility */
@@ -39,9 +39,12 @@ export class RecorderInstaller {
       baseUrl: 'https://artifacts.videodb.io/capture',
       version: '0.3.1',
       checksums: {
-        'darwin-x64': '8b456607ba3628092081d92c1a22fcf4e8156f4e83b2d3d119bf0244eaa870b2',
-        'darwin-arm64': 'cefc35883acd53f63dc50f8deb186ea0a8e17c65e646af8e81a309251a220b9d',
-        'win32-x64': 'e388639c15ab35ac32179d3fc05a363f0f71d4d90265c6b48fb1af56ecae7736',
+        'darwin-x64':
+          '8b456607ba3628092081d92c1a22fcf4e8156f4e83b2d3d119bf0244eaa870b2',
+        'darwin-arm64':
+          'cefc35883acd53f63dc50f8deb186ea0a8e17c65e646af8e81a309251a220b9d',
+        'win32-x64':
+          'e388639c15ab35ac32179d3fc05a363f0f71d4d90265c6b48fb1af56ecae7736',
       },
     };
 
@@ -93,7 +96,7 @@ export class RecorderInstaller {
         MACOS_APP_BUNDLE,
         'Contents',
         'MacOS',
-        'capture',
+        'capture'
       );
     } else if (process.platform === 'win32') {
       binPath = path.join(this.binDir, 'capture.exe');
@@ -305,7 +308,9 @@ export class RecorderInstaller {
             execFileSync('codesign', ['--force', '--sign', '-', appBundlePath]);
             console.log('VideoDB Capture: Code signed .app bundle');
           } catch (e) {
-            console.warn('VideoDB Capture: codesign failed, screen recording may not work on macOS 26+');
+            console.warn(
+              'VideoDB Capture: codesign failed, screen recording may not work on macOS 26+'
+            );
           }
         }
       }
@@ -353,7 +358,7 @@ export class RecorderInstaller {
     }
 
     return new Promise(resolve => {
-      const { spawn } = require('child_process');
+      const { spawn } = require('node:child_process');
       const binaryPath = this.getBinaryPath();
 
       const proc = spawn(binaryPath, ['--version']);

--- a/src/utils/upload.ts
+++ b/src/utils/upload.ts
@@ -7,8 +7,8 @@ import { Audio } from '@/core/audio';
 import { Image } from '@/core/image';
 import type { AudioBase, ImageBase, VideoBase } from '@/interfaces/core';
 import FormData from 'form-data';
-import { createReadStream } from 'fs';
-import { parse } from 'path';
+import { createReadStream } from 'node:fs';
+import { parse } from 'node:path';
 import { HttpClient } from './httpClient';
 
 const { upload_url, collection, upload } = ApiPath;
@@ -62,7 +62,8 @@ export const uploadToServer = async (
     urlToUpload = data.url;
   }
 
-  const name = data.name || ('filePath' in data ? parse(data.filePath).name : undefined);
+  const name =
+    data.name || ('filePath' in data ? parse(data.filePath).name : undefined);
 
   const finalData = {
     url: urlToUpload,


### PR DESCRIPTION
## Summary

Fixes #12

Adds the `node:` prefix to all Node.js built-in module imports across the codebase. This ensures the library is compatible with **Deno** (which requires the `node:` prefix for Node.js built-in compat imports) and aligns with modern Node.js best practices (supported since Node.js v14.18+ / v16+).

**Files updated:**

| File | Modules |
|------|---------|
| `src/utils/upload.ts` | `fs`, `path` |
| `src/capture/installer.ts` | `fs`, `path`, `https`, `crypto`, `child_process` |
| `src/capture/binaryManager.ts` | `child_process`, `readline`, `events`, `path` |
| `src/capture/captureClient.ts` | `events` |
| `lib/installer.js` | `fs`, `path`, `https`, `crypto`, `child_process` |

## Test plan

- [x] `npm run build` passes cleanly
- [x] `npm run typecheck` passes
- [x] Live API smoke test passes (connect + getCollection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)