### PR TITLE
feat: custom headers support

### DIFF
--- a/src/core/connection.ts
+++ b/src/core/connection.ts
@@ -18,7 +18,11 @@ import type {
   ListCaptureSessionsConfig,
   CreateCaptureSessionConfig,
 } from '@/types/capture';
-import { HttpClient, type HttpClientAuthConfig } from '@/utils/httpClient';
+import {
+  HttpClient,
+  type HttpClientAuthConfig,
+  type HttpClientOptions,
+} from '@/utils/httpClient';
 import { uploadToServer } from '@/utils/upload';
 
 const {
@@ -40,13 +44,18 @@ const {
 } = ApiPath;
 
 class VdbHttpClient extends HttpClient {
-  constructor(baseURL: string, authConfig: HttpClientAuthConfig);
-  constructor(baseURL: string, apiKey: string);
   constructor(
     baseURL: string,
-    authConfigOrApiKey: HttpClientAuthConfig | string
+    authConfig: HttpClientAuthConfig,
+    options?: HttpClientOptions
+  );
+  constructor(baseURL: string, apiKey: string, options?: HttpClientOptions);
+  constructor(
+    baseURL: string,
+    authConfigOrApiKey: HttpClientAuthConfig | string,
+    options?: HttpClientOptions
   ) {
-    super(baseURL, authConfigOrApiKey as HttpClientAuthConfig);
+    super(baseURL, authConfigOrApiKey as HttpClientAuthConfig, options);
   }
 }
 
@@ -63,22 +72,32 @@ export class Connection {
    * Create a connection with auth configuration
    * @param baseURL - Base URL for the API
    * @param authConfig - Authentication configuration (apiKey or sessionToken)
+   * @param options - Optional client configuration (custom headers).
+   *                  `headers` are auto-formatted to `x-kebab-case`, mirroring
+   *                  the kwarg-to-header behavior of `videodb-python`.
    */
-  constructor(baseURL: string, authConfig: HttpClientAuthConfig);
+  constructor(
+    baseURL: string,
+    authConfig: HttpClientAuthConfig,
+    options?: HttpClientOptions
+  );
   /**
    * Create a connection with API key (legacy signature)
    * @param baseURL - Base URL for the API
    * @param apiKey - API key for authentication
+   * @param options - Optional client configuration (custom headers)
    * @deprecated Use the object-based constructor instead
    */
-  constructor(baseURL: string, apiKey: string);
+  constructor(baseURL: string, apiKey: string, options?: HttpClientOptions);
   constructor(
     baseURL: string,
-    authConfigOrApiKey: HttpClientAuthConfig | string
+    authConfigOrApiKey: HttpClientAuthConfig | string,
+    options?: HttpClientOptions
   ) {
     this.vhttp = new VdbHttpClient(
       baseURL,
-      authConfigOrApiKey as HttpClientAuthConfig
+      authConfigOrApiKey as HttpClientAuthConfig,
+      options
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ function connect(
     return new Connection(baseURL, { apiKey });
   }
 
-  // Handle new signature: connect({ apiKey?, sessionToken?, baseUrl? })
+  // Handle new signature: connect({ apiKey?, sessionToken?, baseUrl?, headers? })
   const config = configOrApiKey;
   const url = config.baseUrl || VIDEO_DB_API;
 
@@ -53,10 +53,14 @@ function connect(
     );
   }
 
-  return new Connection(url, {
-    apiKey: config.apiKey,
-    sessionToken: config.sessionToken,
-  });
+  return new Connection(
+    url,
+    {
+      apiKey: config.apiKey,
+      sessionToken: config.sessionToken,
+    },
+    config.headers ? { headers: config.headers } : undefined
+  );
 }
 
 export { Collection } from './core/collection';

--- a/src/types/capture.ts
+++ b/src/types/capture.ts
@@ -12,6 +12,12 @@ export interface ConnectionConfig {
   sessionToken?: string;
   /** Base URL for the API (optional, defaults to https://api.videodb.io) */
   baseUrl?: string;
+  /**
+   * Extra headers to attach to every request. Keys are auto-formatted to
+   * `x-kebab-case` (e.g. `org_id` → `x-org-id`), mirroring `videodb-python`'s
+   * kwarg-to-header behavior.
+   */
+  headers?: Record<string, string>;
 }
 
 /**

--- a/src/utils/httpClient.ts
+++ b/src/utils/httpClient.ts
@@ -35,6 +35,32 @@ export interface HttpClientAuthConfig {
 }
 
 /**
+ * Optional configuration for HttpClient
+ *
+ * `headers` is a free-form bag of extra headers merged into every
+ * request. Keys are auto-formatted to `x-kebab-case` to mirror
+ * `videodb-python`'s kwarg-to-header behavior, e.g. `org_id` → `x-org-id`.
+ */
+export interface HttpClientOptions {
+  headers?: Record<string, string>;
+}
+
+const formatExtraHeaders = (
+  headers?: Record<string, string>
+): Record<string, string> => {
+  if (!headers) return {};
+  const formatted: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    const normalized = key.toLowerCase().replace(/_/g, '-');
+    const headerKey = normalized.startsWith('x-')
+      ? normalized
+      : `x-${normalized}`;
+    formatted[headerKey] = value;
+  }
+  return formatted;
+};
+
+/**
  * Api initialization to make axios config
  * options available to all child classes
  * internally.
@@ -55,18 +81,29 @@ export class HttpClient {
    * Create an HttpClient with auth configuration
    * @param baseURL - Base URL for the API
    * @param authConfig - Authentication configuration (apiKey or sessionToken)
+   * @param options - Optional client configuration (custom headers)
    */
-  protected constructor(baseURL: string, authConfig: HttpClientAuthConfig);
+  protected constructor(
+    baseURL: string,
+    authConfig: HttpClientAuthConfig,
+    options?: HttpClientOptions
+  );
   /**
    * Create an HttpClient with API key (legacy signature)
    * @param baseURL - Base URL for the API
    * @param apiKey - API key for authentication
+   * @param options - Optional client configuration (custom headers)
    * @deprecated Use the object-based constructor instead
    */
-  protected constructor(baseURL: string, apiKey: string);
   protected constructor(
     baseURL: string,
-    authConfigOrApiKey: HttpClientAuthConfig | string
+    apiKey: string,
+    options?: HttpClientOptions
+  );
+  protected constructor(
+    baseURL: string,
+    authConfigOrApiKey: HttpClientAuthConfig | string,
+    options?: HttpClientOptions
   ) {
     // Handle both signatures
     const authConfig: HttpClientAuthConfig =
@@ -83,6 +120,7 @@ export class HttpClient {
       headers: {
         'x-access-token': token || '',
         'x-videodb-client': SDK_CLIENT_HEADER,
+        ...formatExtraHeaders(options?.headers),
       },
       timeout: HttpClientDefaultValues.timeout,
     });


### PR DESCRIPTION
## Pull Request

**Description:**
Add support for passing arbitrary custom headers when constructing a `Connection`, bringing the Node SDK to parity with `videodb-python`'s `**kwargs` → `x-*` header behavior. 

**Changes:**
- [x] `HttpClient` accepts a new optional 3rd argument `options?: HttpClientOptions` with a `headers` field; entries are auto-formatted to `x-kebab-case` and merged into the axios instance defaults alongside `x-access-token` and `x-videodb-client`.
- [x] `Connection` (and the inner `VdbHttpClient`) forward the new `options` argument through to `HttpClient`.
- [x] `connect({ ... })` accepts a top-level `headers` field on `ConnectionConfig` and forwards it as `options.headers` to the new `Connection` signature.
- [x] No new runtime dependencies; legacy `connect(apiKey, baseUrl)` positional signature is unchanged.

**Related Issues:**
- Closes #N/A

**Checklist:**
- [x] Code follows project coding standards
- [ ] Tests have been added or updated
- [ ] Code Review
- [ ] Manual test after merge
- [ ] All checks passed