### PR TITLE
fix: subtitle casing

### DIFF
--- a/src/core/video.ts
+++ b/src/core/video.ts
@@ -26,13 +26,14 @@ import {
   NoDataResponse,
 } from '@/types/response';
 import type { Timeline, Transcript } from '@/types/video';
-import { playStream, SnakeKeysToCamelCase } from '@/utils';
+import { fromCamelToSnake, playStream, SnakeKeysToCamelCase } from '@/utils';
 import { HttpClient } from '@/utils/httpClient';
 import {
   DefaultIndexType,
   DefaultSearchType,
   IndexTypeValues,
   SceneExtractionType,
+  SubtitleStyleDefaultValues,
 } from '@/core/config';
 import { SearchFactory } from './search';
 import { SearchResult } from './search/searchResult';
@@ -635,12 +636,13 @@ export class Video implements IVideo {
    *
    */
   public addSubtitle = async (config?: Partial<SubtitleStyleProps>) => {
+    const merged: SubtitleStyleProps = { ...SubtitleStyleDefaultValues, ...config };
     const res = await this.#vhttp.post<
       GenerateStreamResponse,
-      { type: string; subtitle_style: Partial<SubtitleStyleProps> }
+      { type: string; subtitle_style: Record<string, unknown> }
     >([video, this.id, workflow], {
       type: Workflows.addSubtitles,
-      subtitle_style: { ...config },
+      subtitle_style: fromCamelToSnake(merged),
     });
     return res.data.streamUrl;
   };


### PR DESCRIPTION
## Pull Request

  **Description:**
  Fix `Video.addSubtitle` so subtitle styles actually reach the backend. The method was sending camelCase keys under
  `subtitle_style` and had no defaults, so any caller config was silently ignored by the API and `addSubtitle()` with no args sent
  `subtitle_style: {}`. Now it merges the SDK's existing `SubtitleStyleDefaultValues` and converts keys to snake_case before 
  posting, matching the `HttpClient` contract and the Python SDK's behavior.

  **Changes:**
  - [x] Bugfix: convert `subtitle_style` payload from camelCase → snake_case via `fromCamelToSnake` in `Video.addSubtitle`
  (`src/core/video.ts`)
  - [x] Bugfix: apply `SubtitleStyleDefaultValues` when `addSubtitle` is called with no config or a partial config, so the request
  mirrors `videodb-python`'s `SubtitleStyle()` dataclass defaults
  - [x] Imports: pull in `fromCamelToSnake` from `@/utils` and `SubtitleStyleDefaultValues` from `@/core/config`

  **Related Issues:**
  - Closes #<id>

  **Testing:**
  - Manually invoked `video.addSubtitle()` (no args) and verified the outbound request body contains snake_case keys (`font_name`,
  `primary_colour`, `border_style`, `margin_l`, …) populated from `SubtitleStyleDefaultValues`, and that the call returns a valid
  `streamUrl`.
  - Manually invoked `video.addSubtitle({ fontName: "Inter", fontSize: 24, marginV: 40 })` and verified the partial overrides 
  merge over the defaults and serialize as `font_name`, `font_size`, `margin_v` while the rest of the defaults are still sent.
  confirm CLI-supplied flags now actually take effect.
  - `npx tsc --noEmit` passes.

  **Checklist:**
  - [x] Code follows project coding standards
  - [ ] Tests have been added or updated
  - [ ] Code Review
  - [ ] Manual test after merge
  - [ ] All checks passed