### PR TITLE
release `0.2.7`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.2.7] (2026-06-03)
+
+### Added
+
+- Custom headers support in `connect()` via a new `headers` option. Keys are auto-formatted to `x-kebab-case` (e.g. `org_id` → `x-org-id`), mirroring `videodb-python`'s kwarg-to-header behavior
+- `HttpClientOptions` exported alongside `HttpClient` for downstream consumers
+
+### Changed
+
+- All Node.js built-in imports now use the `node:` specifier prefix (`node:fs`, `node:path`, `node:child_process`, etc.) for stricter ESM/CJS interop
+
+### Fixed
+
+- `Video.addSubtitle()` now merges defaults from `SubtitleStyleDefaultValues` and converts keys to snake_case before sending, so partial style overrides are applied correctly server-side
+
+---
+
 ## [0.2.6] (2026-04-03)
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "videodb",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "videodb",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videodb",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "A NodeJS wrapper for VideoDB's API written in TypeScript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Pull Request

  **Description**:
  Release 0.2.7 — patch bump merging accumulated fixes and a small additive change from main into release.

  **Changes**:
  - [x] Custom headers option in connect() — keys auto-format to x-kebab-case, mirroring videodb-python
  - [x] node: prefix on all Node.js built-in imports for stricter ESM/CJS interop
  - [x] Fix Video.addSubtitle() to merge SubtitleStyleDefaultValues and snake_case keys before sending

  Related Issues:
  - #12 
  
  Checklist:
  - [x] Code follows project coding standards
  - [ ] Tests have been added or updated
  - [ ] Code Review
  - [ ] Manual test after merge
  - [ ] All checks passed